### PR TITLE
share validation fix

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -149,7 +149,7 @@ var BlockTemplate = module.exports = function BlockTemplate(
 
     // submit the block header
     this.registerSubmit = function(header, soln){
-        var submission = header + soln;
+        var submission = (header + soln).toLowerCase();
         if (submits.indexOf(submission) === -1){
 
             submits.push(submission);


### PR DESCRIPTION
this fixes an exploit in share validation that allows a miner to submit the same share multiple times by changing the case sensitivity of the nonce submitted