### PR TITLE
Remove previous patch and check entire hex string as lowercase

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -149,7 +149,7 @@ var BlockTemplate = module.exports = function BlockTemplate(
 
     // submit the block header
     this.registerSubmit = function(header, soln){
-        var submission = header + soln;
+        var submission = (header + soln).toLowerCase();
         if (submits.indexOf(submission) === -1){
 
             submits.push(submission);

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -231,7 +231,7 @@ var JobManager = module.exports = function JobManager(options) {
             return shareError([20, 'invalid hex in extraNonce2']);
         }
 
-        if (!job.registerSubmit(extraNonce1.toLowerCase(), extraNonce2.toLowerCase(), nTime, nonce)) {
+        if (!job.registerSubmit(extraNonce1, extraNonce2, nTime, nonce)) {
             return shareError([22, 'duplicate share']);
         }
 


### PR DESCRIPTION
removing previous patch and adding check of entire hex string as lowercase to prevent duplicate shares to include manipulation of nTime or nonce values