### PR TITLE
zhash algo property in coins file

### DIFF
--- a/lib/algoProperties.js
+++ b/lib/algoProperties.js
@@ -44,7 +44,7 @@ var algos = module.exports = global.algos = {
             }
         }
     },
-    'zhash': {
+    'equihash144_5': {
         multiplier: 1,
         diff: parseInt('0x0007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
         hash: function(coinOptions) {
@@ -60,6 +60,37 @@ var algos = module.exports = global.algos = {
             let N = parameters.N || 144
             let K = parameters.K || 5
             let personalization = parameters.personalization || 'BitcoinZ'
+
+            return function() {
+                return ev.verify.apply(
+                    this,
+                    [
+                        arguments[0],
+                        arguments[1],
+                        personalization,
+                        N,
+                        K
+                    ]
+                )
+            }
+        }
+    },
+    'equihash192_7': {
+        multiplier: 1,
+        diff: parseInt('0x0007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+        hash: function(coinOptions) {
+            let parameters = coinOptions.parameters
+            if (!parameters) {
+                parameters = {
+                    N: 192,
+                    K: 7,
+                    personalization: 'ZERO_PoW'
+                }
+            }
+
+            let N = parameters.N || 192
+            let K = parameters.K || 7
+            let personalization = parameters.personalization || 'ZERO_PoW'
 
             return function() {
                 return ev.verify.apply(

--- a/lib/algoProperties.js
+++ b/lib/algoProperties.js
@@ -43,6 +43,37 @@ var algos = module.exports = global.algos = {
                 )
             }
         }
+    },
+    'zhash': {
+        multiplier: 1,
+        diff: parseInt('0x0007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+        hash: function(coinOptions) {
+            let parameters = coinOptions.parameters
+            if (!parameters) {
+                parameters = {
+                    N: 144,
+                    K: 5,
+                    personalization: 'BitcoinZ'
+                }
+            }
+
+            let N = parameters.N || 144
+            let K = parameters.K || 5
+            let personalization = parameters.personalization || 'BitcoinZ'
+
+            return function() {
+                return ev.verify.apply(
+                    this,
+                    [
+                        arguments[0],
+                        arguments[1],
+                        personalization,
+                        N,
+                        K
+                    ]
+                )
+            }
+        }
     }
 };
 


### PR DESCRIPTION
I believe this is the correct "default" layout for a zhash coin. This will add support for the coins algorithm to use "zhash" instead of "equihash". I've only tested on the snowgem testnet via my dev pool.