### PR TITLE
Report rejected shares

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -106,7 +106,7 @@ var StratumClient = function(options){
                     sendJson({
                         id: message.id,
                         result: null,
-                        error: error
+                        error
                     });
                     return;
                 }
@@ -195,8 +195,8 @@ var StratumClient = function(options){
                 if (!considerBan(result)){
                     sendJson({
                         id: message.id,
-                        result: true,
-                        error: null
+                        result: error ? false : true,
+                        error
                     });
                 }
             }


### PR DESCRIPTION
Summary:
Currently, s-nomp is not reporting rejected shares properly back to the
miner. This change modifies the response to the miner to properly report
errors.