### PR TITLE
Move network parameters to the coin.json file

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -22,7 +22,7 @@ exports.txHash = () => txHash
 exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment) => {
     let poolAddrHash = bitcoin.address.fromBase58Check(poolAddress).hash
 
-    let network = bitcoin.networks[coin.symbol]
+    let network = coin.network
     //console.log('network: ', network)
     let txb = new bitcoin.TransactionBuilder(network)
 


### PR DESCRIPTION
Update the transaction.js file to use the coin variable already passed in to create the json variable needed by the bitgo-utxo-lib. This way new coins can be added to s-nomp without a push to the bitgo-utxo-lib repo. 