### PR TITLE
Fix undefined variable error

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -28,9 +28,9 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
 
     // Set sapling or overwinter to either true OR block height to activate.
     // NOTE: if both are set, sapling will be used.
-    if (coin.sapling === true || (typeof coin.sapling === 'number' && coin.sapling <= blockHeight)) {
+    if (coin.sapling === true || (typeof coin.sapling === 'number' && coin.sapling <= rpcData.height)) {
         txb.setVersion(bitcoin.Transaction.ZCASH_SAPLING_VERSION);
-    } else if (coin.overwinter === true || (typeof coin.overwinter === 'number' && coin.overwinter <= blockHeight)) {
+    } else if (coin.overwinter === true || (typeof coin.overwinter === 'number' && coin.overwinter <= rpcData.height)) {
         txb.setVersion(bitcoin.Transaction.ZCASH_OVERWINTER_VERSION);
     }
 


### PR DESCRIPTION
blockHeight is not defined and fails when `sapling` or `overwinter` are set to a block height in the coin config. I've updated the code to use the correct `rpcData.height`.