### PR TITLE
Revert verushash to use working commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "bignum": "^0.13.0",
         "bitgo-utxo-lib": "git+https://github.com/miketout/bitgo-utxo-lib.git",
         "equihashverify": "git+https://github.com/s-nomp/equihashverify.git",
-        "verushash": "git+https://github.com/VerusCoin/verushash-node",
+        "verushash": "git+https://github.com/VerusCoin/verushash-node#e6572f345b8c24e4a1212f6c9eb66c1c400d83e1",
         "merkle-bitcoin": "^1.0.2",
         "promise": "^8.0.1"
     },


### PR DESCRIPTION
Verushash seems to have updated in the last couple days however has not updated s-nomp to work with it. This will use a previously working version temporarily until their devs can fix the issue and new s-nomp users will be able to build successfully.