### PR TITLE
Horizen 20% Treasury update

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -68,11 +68,19 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     if (masternodePayment === false || masternodePayment === undefined) {
         // txs with founders reward
         // This section is for ZEN + other coins
-        if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight) || coin.payAllFounders === true)) {
+        if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {
             // treasury reward or Super Nodes treasury update?
-            if (coin.treasuryRewardUpdateStartBlockHeight && rpcData.height >= coin.treasuryRewardUpdateStartBlockHeight) {
+            if ((coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) && rpcData.height >= (coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight)) {
+                let percentTreasuryReward = coin.percentTreasuryUpdateReward
+                let treasuryRewardStartBlockHeight = coin.treasuryRewardUpdateStartBlockHeight
+                // Horizen treasury reward 20% update
+                if (coin.treasuryReward20pctUpdateStartBlockHeight && rpcData.height >= coin.treasuryReward20pctUpdateStartBlockHeight) {
+                    percentTreasuryReward = coin.percentTreasury20pctUpdateReward
+                    treasuryRewardStartBlockHeight = coin.treasuryReward20pctUpdateStartBlockHeight
+                }
+
                 // treasury reward
-                let indexCF = parseInt(Math.floor(((rpcData.height - coin.treasuryRewardUpdateStartBlockHeight) / coin.treasuryRewardUpdateAddressChangeInterval) % coin.vTreasuryRewardUpdateAddress.length))
+                let indexCF = parseInt(Math.floor(((rpcData.height - treasuryRewardStartBlockHeight) / coin.treasuryRewardUpdateAddressChangeInterval) % coin.vTreasuryRewardUpdateAddress.length))
                 let foundersAddrHash = bitcoin.address.fromBase58Check(coin.vTreasuryRewardUpdateAddress[indexCF]).hash
 
                 // Secure Nodes reward
@@ -93,13 +101,13 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 // pool t-addr
                 txb.addOutput(
                     scriptCompile(poolAddrHash),
-                    Math.round(blockReward.total * (1 - (coin.percentTreasuryUpdateReward + coin.percentSecureNodesReward + coin.percentSuperNodesReward + feePercent) / 100)) + feeReward
+                    Math.round(blockReward.total * (1 - (percentTreasuryReward + coin.percentSecureNodesReward + coin.percentSuperNodesReward + feePercent) / 100)) + feeReward
                 )
 
                 // treasury t-addr
                 txb.addOutput(
                     scriptFoundersCompile(foundersAddrHash),
-                    Math.round(blockReward.total * (coin.percentTreasuryUpdateReward / 100))
+                    Math.round(blockReward.total * (percentTreasuryReward / 100))
                 )
 
                 // Secure Nodes t-addr


### PR DESCRIPTION
This adds support for the upcoming Horizen hardfork (testnet block 369900, mainnet block 455555) changing the community fund block reward to 20% and adding groth sprout shielded transaction support.

Depends on https://github.com/s-nomp/s-nomp/pull/107