### PR TITLE
Support customizable subsidy multiplier

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -30,8 +30,8 @@ var BlockTemplate = module.exports = function BlockTemplate(
     this.difficulty = parseFloat((diff1 / this.target.toNumber()).toFixed(9));
 
     // generate the fees and coinbase tx
-    var blockReward = {
-        "total": (this.rpcData.miner) * 100000000
+    let blockReward = {
+        'total': (this.rpcData.miner) * (coin.subsidyMultipleOfSatoshi || 100000000)
     };
 
     var masternodeReward;


### PR DESCRIPTION
BTH's getblocksubsidy returns satoshi which differs from other chains who
return full coins. With this change, we'll default to expecting full
coin but allow that to be overridden by setting subsidyMultipleOfSatoshi
in the coin's config file.