### PR TITLE
ZelCash nodes

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -67,12 +67,12 @@ var BlockTemplate = module.exports = function BlockTemplate(
     masternodeReward = rpcData.payee_amount;
     masternodePayee = rpcData.payee;
     masternodePayment = rpcData.masternode_payments;
-    zelnodeBasicAddress = rpcData.basic_zelnode_address;
-    zelnodeBasicAmount = rpcData.basic_zelnode_payout;
-    zelnodeSuperAddress = rpcData.super_zelnode_address;
-    zelnodeSuperAmount = rpcData.super_zelnode_payout;
-    zelnodeBamfAddress = rpcData.bamf_zelnode_address;
-    zelnodeBamfAmount = rpcData.bamf_zelnode_payout;
+    zelnodeBasicAddress = coin.payZelNodes ? rpcData.basic_zelnode_address : null;
+    zelnodeBasicAmount = coin.payZelNodes ? (rpcData.basic_zelnode_payout || 0) : 0;
+    zelnodeSuperAddress = coin.payZelNodes ? rpcData.super_zelnode_address : null;
+    zelnodeSuperAmount = coin.payZelNodes ? (rpcData.super_zelnode_payout || 0) : 0;
+    zelnodeBamfAddress = coin.payZelNodes ? rpcData.bamf_zelnode_address : null;
+    zelnodeBamfAmount = coin.payZelNodes ? (rpcData.bamf_zelnode_payout || 0): 0;
 
     var fees = [];
     rpcData.transactions.forEach(function(value) {

--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -39,6 +39,10 @@ var BlockTemplate = module.exports = function BlockTemplate(
     var masternodePayment;
     var zelnodeBasicAddress;
     var zelnodeBasicAmount;
+    var zelnodeSuperAddress;
+    var zelnodeSuperAmount;
+    var zelnodeBamfAddress;
+    var zelnodeBamfAmount;
 
     if (coin.payFoundersReward === true) {
         if (!this.rpcData.founders || this.rpcData.founders.length <= 0) {
@@ -65,6 +69,10 @@ var BlockTemplate = module.exports = function BlockTemplate(
     masternodePayment = rpcData.masternode_payments;
     zelnodeBasicAddress = rpcData.basic_zelnode_address;
     zelnodeBasicAmount = rpcData.basic_zelnode_payout;
+    zelnodeSuperAddress = rpcData.super_zelnode_address;
+    zelnodeSuperAmount = rpcData.super_zelnode_payout;
+    zelnodeBamfAddress = rpcData.bamf_zelnode_address;
+    zelnodeBamfAmount = rpcData.bamf_zelnode_payout;
 
     var fees = [];
     rpcData.transactions.forEach(function(value) {
@@ -86,7 +94,11 @@ var BlockTemplate = module.exports = function BlockTemplate(
             masternodePayee,
             masternodePayment,
             zelnodeBasicAddress,
-            zelnodeBasicAmount
+            zelnodeBasicAmount,
+            zelnodeSuperAddress,
+            zelnodeSuperAmount,
+            zelnodeBamfAddress,
+            zelnodeBamfAmount
         ).toString('hex');
         this.genTxHash = transactions.txHash();
 

--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -37,6 +37,8 @@ var BlockTemplate = module.exports = function BlockTemplate(
     var masternodeReward;
     var masternodePayee;
     var masternodePayment;
+    var zelnodeBasicAddress;
+    var zelnodeBasicAmount;
 
     if (coin.payFoundersReward === true) {
         if (!this.rpcData.founders || this.rpcData.founders.length <= 0) {
@@ -61,6 +63,8 @@ var BlockTemplate = module.exports = function BlockTemplate(
     masternodeReward = rpcData.payee_amount;
     masternodePayee = rpcData.payee;
     masternodePayment = rpcData.masternode_payments;
+    zelnodeBasicAddress = rpcData.basic_zelnode_address;
+    zelnodeBasicAmount = rpcData.basic_zelnode_payout;
 
     var fees = [];
     rpcData.transactions.forEach(function(value) {
@@ -80,7 +84,9 @@ var BlockTemplate = module.exports = function BlockTemplate(
             coin,
             masternodeReward,
             masternodePayee,
-            masternodePayment
+            masternodePayment,
+            zelnodeBasicAddress,
+            zelnodeBasicAmount
         ).toString('hex');
         this.genTxHash = transactions.txHash();
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -19,7 +19,7 @@ const scriptFoundersCompile = address => bitcoin.script.compile([
 let txHash
 exports.txHash = () => txHash
 
-exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount, zelnodeSuperAddress, zelnodeSuperAmount, zelnodeBamfAmount, zelnodeBamfAddress) => {
+exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount, zelnodeSuperAddress, zelnodeSuperAmount, zelnodeBamfAddress, zelnodeBamfAmount) => {
     let poolAddrHash = bitcoin.address.fromBase58Check(poolAddress).hash
 
     let network = coin.network
@@ -216,7 +216,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward
             )
         }
-    } else if (zelnodeBasicAddress === undefined) {
+    } else if (zelnodeBasicAddress === undefined && zelnodeSuperAddress === undefined && zelnodeBamfAddress === undefined) {
         // This section is for SnowGem
         let masternodeAddrHash = masternodePayee ? bitcoin.address.fromBase58Check(masternodePayee).hash : null
 
@@ -296,6 +296,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
         zelnodeBasicAmount = zelnodeBasicAmount || 0;
         zelnodeSuperAmount = zelnodeSuperAmount || 0;
         zelnodeBamfAmount = zelnodeBamfAmount || 0;
+
         // pool t-addr
         txb.addOutput(
             scriptCompile(poolAddrHash),

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -34,6 +34,11 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
         txb.setVersion(bitcoin.Transaction.ZCASH_OVERWINTER_VERSION);
     }
 
+    let payZelNodeRewards = false;
+    if (coin.payZelNodes === true || (typeof coin.payZelNodes === 'number' && coin.payZelNodes <= Date.now() / 1000 )) {
+        payZelNodeRewards = true;
+    }
+
     // input for coinbase tx
     let blockHeightSerial = (rpcData.height.toString(16).length % 2 === 0 ? '' : '0') + rpcData.height.toString(16)
 
@@ -65,7 +70,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     recipients.forEach(recipient => feePercent += recipient.percent)
 
     // TODO: This sorely needs to be updated and simplified
-    if ((masternodePayment === false || masternodePayment === undefined) && (zelnodeBasicAddress === undefined && zelnodeSuperAddress === undefined && zelnodeBamfAddress === undefined)) {
+    if ((masternodePayment === false || masternodePayment === undefined) && (payZelNodeRewards === false)) {
         // txs with founders reward
         // This section is for ZEN + other coins
         if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {
@@ -216,7 +221,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward
             )
         }
-    } else if (zelnodeBasicAddress === undefined && zelnodeSuperAddress === undefined && zelnodeBamfAddress === undefined) {
+    } else if (payZelNodeRewards === false) {
         // This section is for SnowGem
         let masternodeAddrHash = masternodePayee ? bitcoin.address.fromBase58Check(masternodePayee).hash : null
 
@@ -293,9 +298,6 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
         let zelnodeBasicAddrHash = zelnodeBasicAddress ? bitcoin.address.fromBase58Check(zelnodeBasicAddress).hash : null
         let zelnodeSuperAddrHash = zelnodeSuperAddress ? bitcoin.address.fromBase58Check(zelnodeSuperAddress).hash : null
         let zelnodeBamfAddrHash = zelnodeBamfAddress ? bitcoin.address.fromBase58Check(zelnodeBamfAddress).hash : null
-        zelnodeBasicAmount = zelnodeBasicAmount || 0;
-        zelnodeSuperAmount = zelnodeSuperAmount || 0;
-        zelnodeBamfAmount = zelnodeBamfAmount || 0;
 
         // pool t-addr
         txb.addOutput(

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -65,7 +65,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     recipients.forEach(recipient => feePercent += recipient.percent)
 
     // TODO: This sorely needs to be updated and simplified
-    if ((masternodePayment === false || masternodePayment === undefined) && (zelnodeBasicAddress === undefined || zelnodeSuperAddress === undefined || zelnodeBamfAddress === undefined)) {
+    if ((masternodePayment === false || masternodePayment === undefined) && (zelnodeBasicAddress === undefined && zelnodeSuperAddress === undefined && zelnodeBamfAddress === undefined)) {
         // txs with founders reward
         // This section is for ZEN + other coins
         if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -19,7 +19,7 @@ const scriptFoundersCompile = address => bitcoin.script.compile([
 let txHash
 exports.txHash = () => txHash
 
-exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount) => {
+exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount, zelnodeSuperAddress, zelnodeSuperAmount, zelnodeBamfAmount, zelnodeBamfAddress) => {
     let poolAddrHash = bitcoin.address.fromBase58Check(poolAddress).hash
 
     let network = coin.network
@@ -65,7 +65,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     recipients.forEach(recipient => feePercent += recipient.percent)
 
     // TODO: This sorely needs to be updated and simplified
-    if ((masternodePayment === false || masternodePayment === undefined) && zelnodeBasicAddress === undefined) {
+    if ((masternodePayment === false || masternodePayment === undefined) && (zelnodeBasicAddress === undefined || zelnodeSuperAddress === undefined || zelnodeBamfAddress === undefined)) {
         // txs with founders reward
         // This section is for ZEN + other coins
         if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {
@@ -291,17 +291,41 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     } else {
         // case for ZelCash
         let zelnodeBasicAddrHash = zelnodeBasicAddress ? bitcoin.address.fromBase58Check(zelnodeBasicAddress).hash : null
+        let zelnodeSuperAddrHash = zelnodeSuperAddress ? bitcoin.address.fromBase58Check(zelnodeSuperAddress).hash : null
+        let zelnodeBamfAddrHash = zelnodeBamfAddress ? bitcoin.address.fromBase58Check(zelnodeBamfAddress).hash : null
+        zelnodeBasicAmount = zelnodeBasicAmount || 0;
+        zelnodeSuperAmount = zelnodeSuperAmount || 0;
+        zelnodeBamfAmount = zelnodeBamfAmount || 0;
         // pool t-addr
         txb.addOutput(
             scriptCompile(poolAddrHash),
-            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmount
+            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmount - zelnodeSuperAmount - zelnodeBamfAmount
         )
 
         // zelnode basic reward
-        txb.addOutput(
-            scriptCompile(zelnodeBasicAddrHash),
-            Math.round(zelnodeBasicAmount)
-        )
+        if (zelnodeBasicAddrHash != null) {
+            txb.addOutput(
+                scriptCompile(zelnodeBasicAddrHash),
+                Math.round(zelnodeBasicAmount)
+            )
+        }
+
+        // zelnode super reward
+        if (zelnodeSuperAddrHash != null) {
+            txb.addOutput(
+                scriptCompile(zelnodeSuperAddrHash),
+                Math.round(zelnodeSuperAmount)
+            )
+        }
+
+        // zelnode bamf reward
+        if (zelnodeBamfAddrHash != null) {
+            txb.addOutput(
+                scriptCompile(zelnodeBamfAddrHash),
+                Math.round(zelnodeBamfAmount)
+            )
+        }
+
     }
 
     // Segwit support

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -292,15 +292,16 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
         // case for ZelCash
         let zelnodeBasicAddrHash = zelnodeBasicAddress ? bitcoin.address.fromBase58Check(zelnodeBasicAddress).hash : null
         // pool t-addr
+        const zelnodeBasicAmountZEL = zelnodeBasicAmount * 1e8;
         txb.addOutput(
             scriptCompile(poolAddrHash),
-            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmount
+            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmountZEL
         )
 
         // zelnode basic reward
         txb.addOutput(
             scriptCompile(zelnodeBasicAddrHash),
-            Math.round(zelnodeBasicAmount)
+            Math.round(zelnodeBasicAmountZEL)
         )
     }
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -292,16 +292,15 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
         // case for ZelCash
         let zelnodeBasicAddrHash = zelnodeBasicAddress ? bitcoin.address.fromBase58Check(zelnodeBasicAddress).hash : null
         // pool t-addr
-        const zelnodeBasicAmountZEL = zelnodeBasicAmount * 1e8;
         txb.addOutput(
             scriptCompile(poolAddrHash),
-            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmountZEL
+            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmount
         )
 
         // zelnode basic reward
         txb.addOutput(
             scriptCompile(zelnodeBasicAddrHash),
-            Math.round(zelnodeBasicAmountZEL)
+            Math.round(zelnodeBasicAmount)
         )
     }
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -68,11 +68,19 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     if (masternodePayment === false || masternodePayment === undefined) {
         // txs with founders reward
         // This section is for ZEN + other coins
-        if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight) || coin.payAllFounders === true)) {
+        if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {
             // treasury reward or Super Nodes treasury update?
-            if (coin.treasuryRewardUpdateStartBlockHeight && rpcData.height >= coin.treasuryRewardUpdateStartBlockHeight) {
+            if ((coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) && rpcData.height >= (coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight)) {
+                let percentTreasuryReward = coin.percentTreasuryUpdateReward
+                let treasuryRewardStartBlockHeight = coin.treasuryRewardUpdateStartBlockHeight
+                // Horizen treasury reward 20% update
+                if (coin.treasuryReward20pctUpdateStartBlockHeight && rpcData.height >= coin.treasuryReward20pctUpdateStartBlockHeight) {
+                    percentTreasuryReward = coin.percentTreasury20pctUpdateReward
+                    treasuryRewardStartBlockHeight = coin.treasuryReward20pctUpdateStartBlockHeight
+                }
+
                 // treasury reward
-                let indexCF = parseInt(Math.floor(((rpcData.height - coin.treasuryRewardUpdateStartBlockHeight) / coin.treasuryRewardUpdateAddressChangeInterval) % coin.vTreasuryRewardUpdateAddress.length))
+                let indexCF = parseInt(Math.floor(((rpcData.height - treasuryRewardStartBlockHeight) / coin.treasuryRewardUpdateAddressChangeInterval) % coin.vTreasuryRewardUpdateAddress.length))
                 let foundersAddrHash = bitcoin.address.fromBase58Check(coin.vTreasuryRewardUpdateAddress[indexCF]).hash
 
                 // Secure Nodes reward
@@ -93,13 +101,13 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 // pool t-addr
                 txb.addOutput(
                     scriptCompile(poolAddrHash),
-                    Math.round(blockReward.total * (1 - (coin.percentTreasuryUpdateReward + coin.percentSecureNodesReward + coin.percentSuperNodesReward + feePercent) / 100)) + feeReward
+                    Math.round(blockReward.total * (1 - (percentTreasuryReward + coin.percentSecureNodesReward + coin.percentSuperNodesReward + feePercent) / 100)) + feeReward
                 )
 
                 // treasury t-addr
                 txb.addOutput(
                     scriptFoundersCompile(foundersAddrHash),
-                    Math.round(blockReward.total * (coin.percentTreasuryUpdateReward / 100))
+                    Math.round(blockReward.total * (percentTreasuryReward / 100))
                 )
 
                 // Secure Nodes t-addr

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -19,7 +19,7 @@ const scriptFoundersCompile = address => bitcoin.script.compile([
 let txHash
 exports.txHash = () => txHash
 
-exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment) => {
+exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount) => {
     let poolAddrHash = bitcoin.address.fromBase58Check(poolAddress).hash
 
     let network = coin.network
@@ -65,7 +65,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     recipients.forEach(recipient => feePercent += recipient.percent)
 
     // TODO: This sorely needs to be updated and simplified
-    if (masternodePayment === false || masternodePayment === undefined) {
+    if ((masternodePayment === false || masternodePayment === undefined) && zelnodeBasicAddress === undefined) {
         // txs with founders reward
         // This section is for ZEN + other coins
         if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {
@@ -122,7 +122,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                     Math.round(blockReward.total * (coin.percentSuperNodesReward / 100))
                 )
 
-            // founders or treasury reward?
+                // founders or treasury reward?
             } else if (coin.treasuryRewardStartBlockHeight && rpcData.height >= coin.treasuryRewardStartBlockHeight) {
                 // treasury reward
                 let index = parseInt(Math.floor(((rpcData.height - coin.treasuryRewardStartBlockHeight) / coin.treasuryRewardAddressChangeInterval) % coin.vTreasuryRewardAddress.length))
@@ -142,7 +142,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                     scriptFoundersCompile(foundersAddrHash),
                     Math.round(blockReward.total * (coin.percentTreasuryReward / 100))
                 )
-            } else if (coin.payAllFounders === true){
+            } else if (coin.payAllFounders === true) {
                 // SafeCash Addresses
                 // Founders
                 // Chris
@@ -165,7 +165,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 // Calculate and do the pool fee deduction
                 var poolFeeDeductionTotalPercent = 0;
                 // Calculate the total pool fee deduction
-                recipients.forEach(function(recipient){
+                recipients.forEach(function (recipient) {
                     poolFeeDeductionTotalPercent += recipient.percent;
                 });
                 var poolDeductionAmount = Math.round(blockReward.total * (poolFeeDeductionTotalPercent / 100));
@@ -179,15 +179,15 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 );
 
                 // Add founders txs
-                txb.addOutput( scriptFoundersCompile(chrisAddrHash), blockReward.founderSplit);
-                txb.addOutput( scriptFoundersCompile(jimmyAddrHash), blockReward.founderSplit);
-                txb.addOutput( scriptFoundersCompile(scottAddrHash), blockReward.founderSplit);
-                txb.addOutput( scriptFoundersCompile(shelbyAddrHash), blockReward.founderSplit);
-                txb.addOutput( scriptFoundersCompile(lokiAddrHash), blockReward.founderSplit);
+                txb.addOutput(scriptFoundersCompile(chrisAddrHash), blockReward.founderSplit);
+                txb.addOutput(scriptFoundersCompile(jimmyAddrHash), blockReward.founderSplit);
+                txb.addOutput(scriptFoundersCompile(scottAddrHash), blockReward.founderSplit);
+                txb.addOutput(scriptFoundersCompile(shelbyAddrHash), blockReward.founderSplit);
+                txb.addOutput(scriptFoundersCompile(lokiAddrHash), blockReward.founderSplit);
                 // Infrastructure
-                txb.addOutput( scriptFoundersCompile(infrastructureAddrHash), blockReward.infrastructure);
+                txb.addOutput(scriptFoundersCompile(infrastructureAddrHash), blockReward.infrastructure);
                 // Giveaways
-                txb.addOutput( scriptFoundersCompile(giveawaysAddrHash), blockReward.giveaways);
+                txb.addOutput(scriptFoundersCompile(giveawaysAddrHash), blockReward.giveaways);
             } else {
                 // founders reward
                 let index = parseInt(Math.floor(rpcData.height / coin.foundersRewardAddressChangeInterval))
@@ -208,7 +208,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                     Math.round(blockReward.total * (coin.percentFoundersReward / 100))
                 )
             }
-        // no founders rewards :)
+            // no founders rewards :)
         } else {
             // pool t-addr
             txb.addOutput(
@@ -216,7 +216,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward
             )
         }
-    } else {
+    } else if (zelnodeBasicAddress === undefined) {
         // This section is for SnowGem
         let masternodeAddrHash = masternodePayee ? bitcoin.address.fromBase58Check(masternodePayee).hash : null
 
@@ -274,7 +274,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                     Math.round(masternodeReward)
                 )
             }
-        // no founders rewards :)
+            // no founders rewards :)
         } else {
             // pool t-addr
             txb.addOutput(
@@ -288,9 +288,23 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
                 Math.round(masternodeReward)
             )
         }
+    } else {
+        // case for ZelCash
+        let zelnodeBasicAddrHash = zelnodeBasicAddress ? bitcoin.address.fromBase58Check(zelnodeBasicAddress).hash : null
+        // pool t-addr
+        txb.addOutput(
+            scriptCompile(poolAddrHash),
+            Math.round(blockReward.total * (1 - (feePercent / 100))) + feeReward - zelnodeBasicAmount
+        )
+
+        // zelnode basic reward
+        txb.addOutput(
+            scriptCompile(zelnodeBasicAddrHash),
+            Math.round(zelnodeBasicAmount)
+        )
     }
 
-   // Segwit support
+    // Segwit support
     if (rpcData.default_witness_commitment !== undefined) {
         txb.addOutput(new Buffer(rpcData.default_witness_commitment, 'hex'), 0);
     }
@@ -301,7 +315,7 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
         if (coin.burnFees) {
             burn = feeReward
         }
-        recipients.forEach(recipient => { 
+        recipients.forEach(recipient => {
             txb.addOutput(
                 scriptCompile(bitcoin.address.fromBase58Check(recipient.address).hash),
                 Math.round(blockReward.total * (recipient.percent / 100) - burn)


### PR DESCRIPTION
This PR adds payouts to all three tier of zelnodes (zelcash masternodes). Information is taken directly from getblocktemplate rpc call. If there isn't an enabled zelnode, the information is undefined and payout goes to miners. 
Payouts are paid even if they are not yet enforced by the spork. Enforcement of payouts will be activated through spork after 21st of Feb. 
We expected a few nodes to be already up before the enforcement of payouts so pool operators have 2 options:
- update to this code now and be paying to early set up zelnodes eventough they don't have to (favors zelnodes)
- wait and update right before enforcement activated by spork message (favors miners)