### PR TITLE
Get serializedBlockHeight from blocktemplate

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -40,19 +40,10 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     }
 
     // input for coinbase tx
-    let blockHeightSerial = (rpcData.height.toString(16).length % 2 === 0 ? '' : '0') + rpcData.height.toString(16)
-
-    let height = Math.ceil((rpcData.height << 1).toString(2).length / 8)
-    let lengthDiff = blockHeightSerial.length / 2 - height
-    for (let i = 0; i < lengthDiff; i++) {
-        blockHeightSerial = `${blockHeightSerial}00`
-    }
-
-    let length = `0${height}`
     let serializedBlockHeight = new Buffer.concat([
-        new Buffer(length, 'hex'),
+        rpcData.coinbasetxn.data.split('ffffffff')[1].substr(2),
         util.reverseBuffer(new Buffer(blockHeightSerial, 'hex')),
-        new Buffer('00', 'hex') // OP_0
+        new Buffer('0106', 'hex') // OP_0
     ])
 
     txb.addInput(new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex'),

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -42,7 +42,6 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     // input for coinbase tx
     let serializedBlockHeight = new Buffer.concat([
         rpcData.coinbasetxn.data.split('ffffffff')[1].substr(2),
-        util.reverseBuffer(new Buffer(blockHeightSerial, 'hex')),
         new Buffer('0106', 'hex') // OP_0
     ])
 


### PR DESCRIPTION
I have a Znode running and rejecting blocks by mismatch coinbase height, and comparing coinbase of other coins, changed the pattern of serializedBlockHeight, I can't explain the technical reason to change '0106' at the end. Any thoughts?