### PR TITLE
Bugfix: Use 'getblocksubsidy curHeight + 1' to determine coinbase tx …

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -584,10 +584,25 @@ var pool = module.exports = function pool(options, authorizeFn) {
 
 
     function GetBlockTemplate(callback) {
-        function getBlockSubsidyandTemplate() {
+        function  getNextBlockHeight() {
+            // If the current job has a height value (chainTip + 1 from last GBT RPC call) use it, as it's less expensive than doing another RPC call in a function called by each pool fork when polling.
+            // On the first call after a new block has arrived this data will be outdated, but this time window is very small due to RPC polling and jobRebroadcastTimeout, and only relevant on a halving block boundry condition.
+            if (typeof(_this.jobManager) !== 'undefined' && typeof(_this.jobManager.currentJob) !== 'undefined' && typeof(_this.jobManager.currentJob.rpcData) !== 'undefined' && typeof(_this.jobManager.currentJob.rpcData.height) !== 'undefined') {
+                getBlockSubsidyandTemplate(_this.jobManager.currentJob.rpcData.height);
+            // Otherwise do a 'getblockcount' RPC call returning chainTip + 1, this would be the case on GetFirstJob().
+            } else {
+                _this.daemon.cmd(
+                    'getblockcount',
+                    [],
+                    result => result.error ? callback(result.error) : getBlockSubsidyandTemplate(result[0].response + 1)
+                )
+            }
+        }
+
+        function getBlockSubsidyandTemplate(blockheight) {
             _this.daemon.cmd(
                 'getblocksubsidy',
-                [],
+                [blockheight],
                 result => result.error ? callback(result.error) : getBlockTemplate(result[0].response)
             )
         }
@@ -677,7 +692,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
             );
         }
 
-        getBlockSubsidyandTemplate();
+        getNextBlockHeight();
     }
 
 


### PR DESCRIPTION
…vout amounts

Fixes a bug where invalid blocks are generated when a coin reaches a
SubsidyHalvingInterval block.

node-stratum-pool uses the 'getblocksubsidy' RPC call without the optional
'height' argument, which returns the block subsidy reward at the current
block height. Instead 'height' with the block height of the next block
needs to be passed to 'getblocksubsidy'.

As the values from 'getblocksubsidy' are used to set the amounts of coinbase
tx vouts, upon reaching the halving block height boundary, node-stratum-pool would
generate a block that doesn't take the halved block rewards into account, which
gets rejected by the coin daemon.