### PR TITLE
Fix zcash changes to fundingstreams instead of founders addresses

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -44,7 +44,21 @@ var BlockTemplate = module.exports = function BlockTemplate(
     var zelnodeBamfAddress;
     var zelnodeBamfAmount;
 
-    if (coin.payFoundersReward === true) {
+    if(coin.vFundingStreams) {
+        // Zcash has moved to fundingstreams via getblocksubsidy. 
+        // This will calculate block reward and fundingstream totals.
+
+        fundingstreamTotal = 0;
+        for(var i = 0, len = this.rpcData.fundingstreams.length; i < len; i++) {
+            fundingstreamTotal += this.rpcData.fundingstreams[i]["valueZat"];
+        }
+
+        blockReward = {
+            "miner": (this.rpcData.miner * 100000000),
+            "fundingstream": (fundingstreamTotal),
+            "total": (this.rpcData.miner * 100000000 + fundingstreamTotal)
+        }
+    } else if (coin.payFoundersReward === true) {
         if (!this.rpcData.founders || this.rpcData.founders.length <= 0) {
             console.log('Error, founders reward missing for block template!');
         } else if (coin.payAllFounders){

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -616,12 +616,14 @@ var pool = module.exports = function pool(options, authorizeFn) {
                         callback(result.error);
                     } else {
                         result.response.miner = subsidy.miner;
-                        if (!result.response.founders)
+
+                        if (options.coin.vFundingStreams) {
+                            //Zcash uses fundingstreams instead of founders reward
+                            result.response.fundingstreams = subsidy.fundingstreams
+                        } else if (!result.response.founders)
                         {
                             result.response.founders = (subsidy.founders || subsidy.community || (subsidy['founders-chris'] + subsidy['founders-jimmy'] + subsidy['founders-scott'] + subsidy['founders-shelby'] + subsidy['founders-loki'] ));
-                        }
-                        else
-                        {
+                        } else {
                             // founders already set in block template
                             // console.log(result.response.founders);
                         }

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -69,8 +69,27 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
     let feePercent = 0
     recipients.forEach(recipient => feePercent += recipient.percent)
 
+    // Zcash uses fundingstreams from getblocksubsidy and no longer uses founders addresses in coins
+    if(coin.vFundingStreams) {
+
+        // pool t-addr
+        txb.addOutput(
+            scriptCompile(poolAddrHash),
+            Math.round(Math.round(blockReward.total * (1 - (coin.percentFoundersReward + feePercent) / 100) + feeReward))
+        );
+
+        // loop through founders and add them to our coinbase transaction
+        rpcData.fundingstreams.map((founderItem) => {
+            txb.addOutput(
+                scriptFoundersCompile(bitcoin.address.fromBase58Check(founderItem.address).hash),
+                founderItem.valueZat
+            );
+        });
+
+    }
+
     // TODO: This sorely needs to be updated and simplified
-    if ((masternodePayment === false || masternodePayment === undefined) && payZelNodeRewards === false && !rpcData.coinbase_required_outputs) {
+    else if ((masternodePayment === false || masternodePayment === undefined) && payZelNodeRewards === false && !rpcData.coinbase_required_outputs) {
         // txs with founders reward
         // This section is for ZEN + other coins
         if (coin.payFoundersReward === true && ((coin.maxFoundersRewardBlockHeight >= rpcData.height || coin.treasuryRewardStartBlockHeight || coin.treasuryRewardUpdateStartBlockHeight || coin.treasuryReward20pctUpdateStartBlockHeight) || coin.payAllFounders === true)) {


### PR DESCRIPTION
Zcash has moved from using founders addresses to "Funding Streams". This will require the coins file for ZEC to be updated to include `"vFundingStreams": true`