### PR TITLE
support for upcoming Flux (Zel) fork

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -37,12 +37,20 @@ var BlockTemplate = module.exports = function BlockTemplate(
     var masternodeReward;
     var masternodePayee;
     var masternodePayment;
+
     var zelnodeBasicAddress;
     var zelnodeBasicAmount;
     var zelnodeSuperAddress;
     var zelnodeSuperAmount;
     var zelnodeBamfAddress;
     var zelnodeBamfAmount;
+
+    var fluxSwapPoolAddress;
+    var fluxSwapPoolAmount;
+    var fluxFoundationPoolAddress
+    var fluxFoundationPoolAmount;
+    var fluxExchangePoolAddress;
+    var fluxExchangePoolAmount;
 
     if(coin.vFundingStreams) {
         // Zcash has moved to fundingstreams via getblocksubsidy. 
@@ -117,12 +125,20 @@ var BlockTemplate = module.exports = function BlockTemplate(
     masternodeReward = rpcData.payee_amount;
     masternodePayee = rpcData.payee;
     masternodePayment = rpcData.masternode_payments;
+
     zelnodeBasicAddress = coin.payZelNodes ? rpcData.basic_zelnode_address : null;
     zelnodeBasicAmount = coin.payZelNodes ? (rpcData.basic_zelnode_payout || 0) : 0;
     zelnodeSuperAddress = coin.payZelNodes ? rpcData.super_zelnode_address : null;
     zelnodeSuperAmount = coin.payZelNodes ? (rpcData.super_zelnode_payout || 0) : 0;
     zelnodeBamfAddress = coin.payZelNodes ? rpcData.bamf_zelnode_address : null;
     zelnodeBamfAmount = coin.payZelNodes ? (rpcData.bamf_zelnode_payout || 0): 0;
+
+    fluxSwapPoolAddress = coin.payZelNodes ? rpcData.swap_pool_fund_address : null;
+    fluxSwapPoolAmount = coin.payZelNodes ? (rpcData.swap_pool_fund_amount || 0) : 0;
+    fluxFoundationPoolAddress = coin.payZelNodes ? rpcData.foundation_fund_address : null;
+    fluxFoundationPoolAmount = coin.payZelNodes ? (rpcData.foundation_fund_amount || 0) : 0;
+    fluxExchangePoolAddress = coin.payZelNodes ? rpcData.exchange_fund_address : null;
+    fluxExchangePoolAmount = coin.payZelNodes ? (rpcData.exchange_fund_amount || 0): 0;
 
     var fees = [];
     rpcData.transactions.forEach(function(value) {
@@ -148,7 +164,13 @@ var BlockTemplate = module.exports = function BlockTemplate(
             zelnodeSuperAddress,
             zelnodeSuperAmount,
             zelnodeBamfAddress,
-            zelnodeBamfAmount
+            zelnodeBamfAmount,
+            fluxSwapPoolAddress,
+            fluxSwapPoolAmount,
+            fluxExchangePoolAddress,
+            fluxExchangePoolAmount,
+            fluxFoundationPoolAddress,
+            fluxFoundationPoolAmount
         ).toString('hex');
         this.genTxHash = transactions.txHash();
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -19,7 +19,7 @@ const scriptFoundersCompile = address => bitcoin.script.compile([
 let txHash
 exports.txHash = () => txHash
 
-exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount, zelnodeSuperAddress, zelnodeSuperAmount, zelnodeBamfAddress, zelnodeBamfAmount) => {
+exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAddress, poolHex, coin, masternodeReward, masternodePayee, masternodePayment, zelnodeBasicAddress, zelnodeBasicAmount, zelnodeSuperAddress, zelnodeSuperAmount, zelnodeBamfAddress, zelnodeBamfAmount, fluxSwapPoolAddress, fluxSwapPoolAmount, fluxExchangePoolAddress, fluxExchangePoolAmount, fluxFoundationPoolAddress, fluxFoundationPoolAmount) => {
     let poolAddrHash = bitcoin.address.fromBase58Check(poolAddress).hash
 
     let network = coin.network
@@ -492,6 +492,35 @@ exports.createGeneration = (rpcData, blockReward, feeReward, recipients, poolAdd
             txb.addOutput(
                 scriptCompile(zelnodeBamfAddrHash),
                 Math.round(zelnodeBamfAmount)
+            )
+        }
+
+        // Flux fork. Adds additional funds generation for swap pools, exchanges, foundation
+        let fluxSwapPoolAddrHash = fluxSwapPoolAddress ? bitcoin.address.fromBase58Check(fluxSwapPoolAddress).hash : null
+        let fluxFoundationPoolAddrHash = fluxFoundationPoolAddress ? bitcoin.address.fromBase58Check(fluxFoundationPoolAddress).hash : null
+        let fluxExchangePoolAddrHash = fluxExchangePoolAddress ? bitcoin.address.fromBase58Check(fluxExchangePoolAddress).hash : null
+
+        // swap fund
+        if (fluxSwapPoolAddrHash != null) {
+            txb.addOutput(
+                scriptCompile(fluxSwapPoolAddrHash),
+                Math.round(fluxSwapPoolAmount)
+            )
+        }
+
+        // foundation fund
+        if (fluxFoundationPoolAddrHash != null) {
+            txb.addOutput(
+                scriptCompile(fluxFoundationPoolAddrHash),
+                Math.round(fluxFoundationPoolAmount)
+            )
+        }
+
+        // exchange fund
+        if (fluxExchangePoolAddrHash != null) {
+            txb.addOutput(
+                scriptCompile(fluxExchangePoolAddrHash),
+                Math.round(fluxExchangePoolAmount)
             )
         }
     }


### PR DESCRIPTION
- Zel is rebranding to Flux and after the fork several pools will be created - for exchanges, foundation and periodically for swaps to coexist on multiple chains. That data is provided in getblocktemplate similarily how zelnodes operate.

Pools shall update prior 10th of April.